### PR TITLE
Version 1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "lib/glm"]
 	path = lib/glm
 	url = https://github.com/g-truc/glm.git
+	branch = 0.9.8
 [submodule "lib/msdfgen/msdfgen"]
 	path = lib/msdfgen/msdfgen
 	url = https://github.com/Chlumsky/msdfgen.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,8 @@ add_custom_target(touch_dummy ALL
     COMMAND ${CMAKE_COMMAND} -E touch ${DATA_SOURCE_DIR}/dummy
     DEPENDS make_data_directory
 )
-add_custom_target(create_data_symlink ALL
-    COMMAND ${CMAKE_COMMAND} -E create_symlink ${DATA_SOURCE_DIR} ${DATA_BINARY_DIR}
+add_custom_target(copy_data_directory ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${DATA_SOURCE_DIR} ${DATA_BINARY_DIR}
     DEPENDS touch_dummy
 )
-add_dependencies(piksel create_data_symlink)
+add_dependencies(piksel copy_data_directory)

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,6 +1,6 @@
 ![logo](_media/logo.svg)
 
-# piksel <small>1.1</small>
+# piksel <small>1.2</small>
 
 > A simple 2D graphics library for C++
 

--- a/docs/gettingstarted/buildproject.md
+++ b/docs/gettingstarted/buildproject.md
@@ -4,8 +4,6 @@
 
 ## Build natively ![linux](_media/linux.svg) ![macos](_media/macos.svg)
 
-!> Native builds are currently not supported on **Windows**. Please [build for the web](gettingstarted/buildproject.md#build-for-the-web-) instead for now.
-
 #### Generate the Makefile using cmake
 
 In your project's root directory (e.g. `myproject`), create a new folder `build_native`. Open a terminal, navigate to `build_native` and enter:
@@ -34,9 +32,43 @@ From now on, everytime you modify your sourcecode, you merely need to call `make
 ./index
 ```
 
+## Build natively ![windows](_media/windows.svg)
+
+*Credit goes to **Tobias Kallmeier** for finding a way to make native builds happen on **Windows**.*
+
+>For native builds on **Windows**, [mingw-w64](https://mingw-w64.org/) is required to be installed on your machine. In the downloads section there is a link called `MingW-W64-builds` leading to the latest release on sourceforge.
+
+#### Generate the Makefile using cmake
+
+In your project's root directory (e.g. `myproject`), create a new folder `build_native`. Open a terminal, navigate to `build_native` and enter:
+
+```cmd
+cmake .. -G "MinGW Makefiles"
+```
+
+[CMake](https://cmake.org/) will do it's thing, generating all kinds of files, including a new file called `Makefile`.
+
+#### Compile using mingw32-make
+
+Make is a tool that will build your app based on the instructions provided by the so called Makefile. It is as simple as entering a single command:
+
+```cmd
+mingw32-make
+```
+
+The first time you execute make it will take some time until it's finished. Consequent builds will be much faster!
+
+From now on, everytime you modify your sourcecode, you merely need to call `mingw32-make` to rebuild your app.
+
+#### Launch your app
+
+```cmd
+.\index.exe
+```
+
 ## Build for the web ![linux](_media/linux.svg) ![macos](_media/macos.svg) ![windows](_media/windows.svg)
 
->If you are a **Windows** user, please refer to [this guide](gettingstarted/buildonwindows.md#how-to-build-on-windows) before you continue.
+>If you are a **Windows** user, please refer to [this guide](gettingstarted/windowsaddendum.md) before you continue.
 
 To build for the web, you first need to install Emscripten by following the [WebAssembly developer's guide](https://webassembly.org/getting-started/developers-guide/).
 

--- a/docs/gettingstarted/setupproject.md
+++ b/docs/gettingstarted/setupproject.md
@@ -22,6 +22,8 @@ Let's continue by cloning the piksel repository from GitHub. For this we will us
 git clone --recursive https://github.com/bernhardfritz/piksel.git
 ```
 
+>**Windows** users need to patch one of piksel's depencencies for native builds to work correctly. This can be done by entering `cd piksel` followed by `git apply windows.patch`.
+
 `piksel` does not require you to install any dependencies to your system. All required dependencies are self-contained within `piksel`.
 
 ## Write code

--- a/docs/gettingstarted/troubleshooting.md
+++ b/docs/gettingstarted/troubleshooting.md
@@ -45,3 +45,16 @@ cd cmake-$version.$build/
 make -j4
 sudo make install
 ```
+
+## The RandR headers were not found
+
+This error can happen during `Makefile` generation using `cmake ..` as part of the native compilation process on Linux. Some distributions do not include packages like `libgl1-mesa-dev` or `xorg-dev` per default. You can install them by typing:
+
+**Linux:**
+```bash
+sudo apt update
+sudo apt install libgl1-mesa-dev
+sudo apt install xorg-dev
+```
+
+After cleaning your build directory, you should be able to generate a `Makefile` using `cmake ..`.

--- a/docs/gettingstarted/windowsaddendum.md
+++ b/docs/gettingstarted/windowsaddendum.md
@@ -1,6 +1,6 @@
-## How to build on Windows
+## Build for the web (Windows addendum)
 
-At the moment only web builds are supported on Windows using the **Windows Subsystem for Linux** (WSL). In theory native builds on Windows should also be possible, but that would require some adaptions to piksel's [CMakeLists.txt](https://github.com/bernhardfritz/piksel/blob/master/CMakeLists.txt). If you get a native build to run on Windows, <a href="javascript:void(0);" onclick="document.querySelector('.gitter-open-chat-button').click();">please let us know</a>!
+At the moment web builds on Windows are only supported using the **Windows Subsystem for Linux** (WSL).
 
 #### How to set up WSL
 
@@ -17,7 +17,5 @@ cd /mnt/c
 ```
 
 This allows you to write your code in Windows, using the code editors you are accustomed to and only use WSL to build.
-
-#### Build for the web on Windows
 
 With WSL set up, you can continue the [Build for the web](gettingstarted/buildproject.md#build-for-the-web-) guide.

--- a/windows.patch
+++ b/windows.patch
@@ -1,0 +1,16 @@
+Submodule lib/msdfgen/msdfgen contains modified content
+diff --git a/lib/msdfgen/msdfgen/core/SignedDistance.h b/lib/msdfgen/msdfgen/core/SignedDistance.h
+index 034210f..5bc2beb 100644
+--- a/lib/msdfgen/msdfgen/core/SignedDistance.h
++++ b/lib/msdfgen/msdfgen/core/SignedDistance.h
+@@ -1,6 +1,10 @@
+ 
+ #pragma once
+ 
++#ifdef INFINITE
++#undef INFINITE
++#endif
++
+ namespace msdfgen {
+ 
+ /// Represents a signed distance and alignment, which together can be compared to uniquely determine the closest edge segment.


### PR DESCRIPTION
* add support for native builds on Windows (credits to Tobias Kallmeier)
* modify docs to reflect changes related to native Windows builds
* use fixed version 0.9.8 for submodule glm to prevent build from breaking